### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/com/github/tminglei/bind/Constraints.java
+++ b/src/main/java/com/github/tminglei/bind/Constraints.java
@@ -19,6 +19,8 @@ import static com.github.tminglei.bind.FrameworkUtils.*;
 public class Constraints {
     private static final Logger logger = LoggerFactory.getLogger(Constraints.class);
 
+    private Constraints() {}
+
     /////////////////////////////////////  pre-defined constraints  /////////////////////////
 
     public static Constraint required() {

--- a/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
+++ b/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
@@ -28,6 +28,8 @@ public class FrameworkUtils {
     public static final Constraint PASS_VALIDATE
             = (name, data, messages, options) -> Collections.EMPTY_LIST;
 
+    private FrameworkUtils() {}
+
     public static <T> List<T> unmodifiableList(List<T> list) {
         return list == null ? Collections.EMPTY_LIST : Collections.unmodifiableList(list);
     }

--- a/src/main/java/com/github/tminglei/bind/Mappings.java
+++ b/src/main/java/com/github/tminglei/bind/Mappings.java
@@ -22,6 +22,8 @@ import static com.github.tminglei.bind.FrameworkUtils.*;
 public class Mappings {
     private static final Logger logger = LoggerFactory.getLogger(Mappings.class);
 
+    private Mappings() {}
+
     ///////////////////////////////////  pre-defined field mappings  ////////////////////////
 
     /**

--- a/src/main/java/com/github/tminglei/bind/Processors.java
+++ b/src/main/java/com/github/tminglei/bind/Processors.java
@@ -21,6 +21,8 @@ import static com.github.tminglei.bind.FrameworkUtils.*;
 public class Processors {
     private static final Logger logger = LoggerFactory.getLogger(Processors.class);
 
+    private Processors() {}
+
     ///////////////////////////////////  pre-defined pre-processors  //////////////////////////
 
     public static PreProcessor trim() {

--- a/src/main/java/com/github/tminglei/bind/PropertyUtils.java
+++ b/src/main/java/com/github/tminglei/bind/PropertyUtils.java
@@ -13,6 +13,8 @@ import java.util.*;
  */
 public class PropertyUtils {
 
+    private PropertyUtils() {}
+
     public static Object readProperty( Object bean, String propName ) {
         Objects.requireNonNull(bean, "Bean object is NULL!");
         Objects.requireNonNull(propName, "Property name is NULL!");

--- a/src/main/java/com/github/tminglei/bind/Transformers.java
+++ b/src/main/java/com/github/tminglei/bind/Transformers.java
@@ -17,6 +17,9 @@ public class Transformers {
     static final Logger logger = LoggerFactory.getLogger(Transformers.class);
 
     static final Registry REGISTRY = new Registry();
+
+    private Transformers() {}
+
     static {
         register(Byte.class, Byte.TYPE, (Function<Byte, Byte>) FrameworkUtils.PASS_THROUGH);
         register(Short.class, Short.TYPE, (Function<Short, Short>) FrameworkUtils.PASS_THROUGH);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1118 - Utility classes should not have public constructors.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
George Kankava