### PR TITLE
Multiple code improvements - squid:S1192, squid:UselessParenthesesCheck, squid:S1213

### DIFF
--- a/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
+++ b/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
@@ -28,6 +28,10 @@ public class FrameworkUtils {
     public static final Constraint PASS_VALIDATE
             = (name, data, messages, options) -> Collections.EMPTY_LIST;
 
+
+    private static final Pattern OBJ_ELEMENT_NAME = Pattern.compile("^(.*)\\.([^\\.]+)$");
+    private static final Pattern ARR_ELEMENT_NAME = Pattern.compile("^(.*)\\[([\\d]+)\\]$");
+
     public static <T> List<T> unmodifiableList(List<T> list) {
         return list == null ? Collections.EMPTY_LIST : Collections.unmodifiableList(list);
     }
@@ -75,8 +79,6 @@ public class FrameworkUtils {
         }
     }
 
-    static final Pattern OBJ_ELEMENT_NAME = Pattern.compile("^(.*)\\.([^\\.]+)$");
-    static final Pattern ARR_ELEMENT_NAME = Pattern.compile("^(.*)\\[([\\d]+)\\]$");
     // return (parent, name, isArray:false) or (name, index, isArray:true)
     static String[] splitName(String name) {
         logger.trace("splitting name for {}", name);
@@ -267,7 +269,7 @@ public class FrameworkUtils {
     // make a Constraint which will try to check and collect errors
     public static <T> Constraint
             checking(Function<String, T> check, String messageOrKey, boolean isKey, String... extraMessageArgs) {
-        return mkSimpleConstraint(((label, vString, messages) -> {
+        return mkSimpleConstraint((label, vString, messages) -> {
             logger.debug("checking for {}", vString);
 
             if (isEmptyStr(vString)) return null;
@@ -281,12 +283,12 @@ public class FrameworkUtils {
                     return String.format(msgTemplate, messageArgs.toArray());
                 }
             }
-        }), null);
+        }, null);
     }
 
     // make a compound Constraint, which checks whether any inputting constraints passed
     public static Constraint anyPassed(Constraint... constraints) {
-        return ((name, data, messages, options) -> {
+        return (name, data, messages, options) -> {
             logger.debug("checking any passed for {}", name);
 
             List<Map.Entry<String, String>> errErrors = new ArrayList<>();
@@ -303,7 +305,7 @@ public class FrameworkUtils {
                     .collect(Collectors.joining(", ", "[", "]"));
             return Arrays.asList(entry(name,
                     String.format(messages.get("error.anypassed"), label, errStr)));
-        });
+        };
     }
 
     // Computes the available indexes for the given key in this set of data.

--- a/src/main/java/com/github/tminglei/bind/Mappings.java
+++ b/src/main/java/com/github/tminglei/bind/Mappings.java
@@ -21,6 +21,9 @@ import static com.github.tminglei.bind.FrameworkUtils.*;
  */
 public class Mappings {
     private static final Logger logger = LoggerFactory.getLogger(Mappings.class);
+    public static final String D_$ = "^[\\d]+$";
+    public static final String S_NOT_A_DATE_LONG = "'%s' not a date long";
+    public static final String ERROR_PATTERN = "error.pattern";
 
     ///////////////////////////////////  pre-defined field mappings  ////////////////////////
 
@@ -171,7 +174,7 @@ public class Mappings {
                 InputMode.SINGLE,
                 mkSimpleConverter(s -> {
                     if (isEmptyStr(s)) return null;
-                    else if (s.matches("^[\\d]+$")) {
+                    else if (s.matches(D_$)) {
                         Instant instant = new Date(Long.parseLong(s)).toInstant();
                         return LocalDateTime.ofInstant(instant, ZoneId.of("UTC")).toLocalDate();
                     } else {
@@ -179,8 +182,8 @@ public class Mappings {
                     }
                 }), new MappingMeta(LocalDate.class)
             ).constraint(anyPassed(
-                    checking(s -> new Date(Long.parseLong(s)), "'%s' not a date long", false),
-                    checking(formatter::parse, "error.pattern", true, pattern)
+                    checking(s -> new Date(Long.parseLong(s)), S_NOT_A_DATE_LONG, false),
+                    checking(formatter::parse, ERROR_PATTERN, true, pattern)
                 )).constraint(constraints);
         }
 
@@ -198,7 +201,7 @@ public class Mappings {
                 InputMode.SINGLE,
                 mkSimpleConverter(s -> {
                     if (isEmptyStr(s)) return null;
-                    else if (s.matches("^[\\d]+$")) {
+                    else if (s.matches(D_$)) {
                         Instant instant = new Date(Long.parseLong(s)).toInstant();
                         return LocalDateTime.ofInstant(instant, ZoneId.of("UTC"));
                     } else {
@@ -206,8 +209,8 @@ public class Mappings {
                     }
                 }), new MappingMeta(LocalDateTime.class)
             ).constraint(anyPassed(
-                    checking(s -> new Date(Long.parseLong(s)), "'%s' not a date long", false),
-                    checking(formatter::parse, "error.pattern", true, pattern)
+                    checking(s -> new Date(Long.parseLong(s)), S_NOT_A_DATE_LONG, false),
+                    checking(formatter::parse, ERROR_PATTERN, true, pattern)
                 )).constraint(constraints);
         }
 
@@ -225,7 +228,7 @@ public class Mappings {
                 InputMode.SINGLE,
                 mkSimpleConverter(s -> {
                     if (isEmptyStr(s)) return null;
-                    else if (s.matches("^[\\d]+$")) {
+                    else if (s.matches(D_$)) {
                         Instant instant = new Date(Long.parseLong(s)).toInstant();
                         return LocalDateTime.ofInstant(instant, ZoneId.of("UTC")).toLocalTime();
                     } else {
@@ -233,8 +236,8 @@ public class Mappings {
                     }
                 }), new MappingMeta(LocalTime.class)
             ).constraint(anyPassed(
-                    checking(s -> new Date(Long.parseLong(s)), "'%s' not a date long", false),
-                    checking(formatter::parse, "error.pattern", true, pattern)
+                    checking(s -> new Date(Long.parseLong(s)), S_NOT_A_DATE_LONG, false),
+                    checking(formatter::parse, ERROR_PATTERN, true, pattern)
                 )).constraint(constraints);
         }
 
@@ -250,7 +253,7 @@ public class Mappings {
     public static <T> Mapping<T> ignored(T instead) {
         return new FieldMapping<T>(
                 InputMode.POLYMORPHIC,
-                ((name, data) -> instead),
+                (name, data) -> instead,
                 new MappingMeta(instead.getClass())
             ).options(o -> o._ignoreConstraints(true));
         }
@@ -278,14 +281,14 @@ public class Mappings {
     public static <T> Mapping<Optional<T>> optional(Mapping<T> base, Constraint... constraints) {
         return new FieldMapping<Optional<T>>(
                 base.options()._inputMode(),
-                ((name, data) -> {
+                (name, data) -> {
                     logger.debug("optional - converting {}", name);
 
                     if (isEmptyInput(name, data, base.options()._inputMode())) {
                         return Optional.empty();
                     } else return Optional.of(base.convert(name, data));
-                }),
-                ((name, data, messages, options) -> {
+                },
+                (name, data, messages, options) -> {
                     logger.debug("optional - validating {}", name);
 
                     if (isEmptyInput(name, data, base.options()._inputMode())) {
@@ -295,7 +298,7 @@ public class Mappings {
                                 .options(o -> o._label(o._label().orElse(options._label().orElse(null))))
                                 .validate(name, data, messages, options);
                     }
-                }), new MappingMeta(Optional.class, base)
+                }, new MappingMeta(Optional.class, base)
             ).options(o -> o._ignoreConstraints(true))
                 .constraint(constraints);
         }
@@ -310,20 +313,20 @@ public class Mappings {
     public static <T> Mapping<List<T>> list(Mapping<T> base, Constraint... constraints) {
         return new FieldMapping<List<T>>(
                 InputMode.MULTIPLE,
-                ((name, data) -> {
+                (name, data) -> {
                     logger.debug("list - converting {}", name);
 
                     return indexes(name, data).stream()
                             .map(i -> base.convert(name + "[" + i + "]", data))
                             .collect(Collectors.toList());
-                }),
-                ((name, data, messages, options) -> {
+                },
+                (name, data, messages, options) -> {
                     logger.debug("list - validating {}", name);
 
                     return indexes(name, data).stream()
                             .flatMap(i -> base.validate(name + "[" + i + "]", data, messages, options).stream())
                             .collect(Collectors.toList());
-                }), new MappingMeta(List.class, base)
+                }, new MappingMeta(List.class, base)
             ).constraint(constraints);
         }
 
@@ -340,7 +343,7 @@ public class Mappings {
     public static <K, V> Mapping<Map<K, V>> map(Mapping<K> kBase, Mapping<V> vBase, Constraint... constraints) {
         return new FieldMapping<Map<K, V>>(
                 InputMode.MULTIPLE,
-                ((name, data) -> {
+                (name, data) -> {
                     logger.debug("map - converting {}", name);
 
                     return keys(name, data).stream()
@@ -356,8 +359,8 @@ public class Mappings {
                                 Map.Entry::getKey,
                                 Map.Entry::getValue
                         ));
-                }),
-                ((name, data, messages, options) -> {
+                },
+                (name, data, messages, options) -> {
                     logger.debug("map - validating {}", name);
 
                     return keys(name, data).stream()
@@ -370,7 +373,7 @@ public class Mappings {
                             ).stream();
                         })
                         .collect(Collectors.toList());
-                }), new MappingMeta(Map.class, kBase, vBase)
+                }, new MappingMeta(Map.class, kBase, vBase)
             ).constraint(constraints);
         }
 

--- a/src/main/java/com/github/tminglei/bind/Processors.java
+++ b/src/main/java/com/github/tminglei/bind/Processors.java
@@ -100,7 +100,7 @@ public class Processors {
     }
     public static PreProcessor expandJson(String prefix) {
         return mkPreProcessorWithMeta((prefix1, data, options) -> {
-            logger.debug("expanding json at '{}'", (prefix == null ? prefix1 : prefix));
+            logger.debug("expanding json at '{}'", prefix == null ? prefix1 : prefix);
 
             String thePrefix = prefix == null ? prefix1 : prefix;
             String jsonStr = data.get(thePrefix);
@@ -132,7 +132,7 @@ public class Processors {
     }
     public static PreProcessor expandJsonKeys(String prefix) {
         return mkPreProcessorWithMeta((prefix1, data, options) -> {
-            logger.debug("expanding json keys at '{}'", (prefix == null ? prefix1 : prefix));
+            logger.debug("expanding json keys at '{}'", prefix == null ? prefix1 : prefix);
 
             Map<String, String> data1 = expandJson(prefix).apply(prefix1, data, options);
             Map<String, String> data2 = expandListKeys(prefix).apply(prefix1, data1, options);
@@ -149,7 +149,7 @@ public class Processors {
     }
     public static PreProcessor expandListKeys(String prefix) {
         return mkPreProcessorWithMeta((prefix1, data, options) -> {
-            logger.debug("expanding list keys at '{}'", (prefix == null ? prefix1 : prefix));
+            logger.debug("expanding list keys at '{}'", prefix == null ? prefix1 : prefix);
 
             String thePrefix = prefix == null ? prefix1 : prefix;
             Pattern p = Pattern.compile("^" + Pattern.quote(thePrefix) + "\\[[\\d]+\\].*");
@@ -228,7 +228,7 @@ public class Processors {
      */
     public static Function<List<Map.Entry<String, String>>, Map<String, Object>>
                 errsTree() {
-        return ((errors) -> {
+        return (errors) -> {
             logger.debug("converting errors list to errors tree");
 
             Map<String, Object> root = new HashMap<>();
@@ -239,7 +239,7 @@ public class Processors {
                 workObj.add(error.getValue());
             }
             return root;
-        });
+        };
     }
 
     /////////////////////////////////  pre-defined touched checkers  /////////////////////
@@ -250,13 +250,13 @@ public class Processors {
      * @return new created touched checker
      */
     public static TouchedChecker listTouched(List<String> touched) {
-        return ((prefix, data) -> {
+        return (prefix, data) -> {
             logger.debug("checking touched in list for '{}'", prefix);
 
             return touched.stream()
                     .filter(key -> key.startsWith(prefix))
                     .count() > 0;
-        });
+        };
     }
 
     /**
@@ -266,7 +266,7 @@ public class Processors {
      * @return new created touched checker
      */
     public static TouchedChecker prefixTouched(String dataPrefix, String touchedPrefix) {
-        return ((prefix, data) -> {
+        return (prefix, data) -> {
             logger.debug("checking touched with data prefix '{}' and touched prefix '{}' for '{}'",
                     dataPrefix, touchedPrefix, prefix);
 
@@ -274,6 +274,6 @@ public class Processors {
             return data.keySet().stream()
                     .filter(key -> key.startsWith(prefixToBeChecked))
                     .count() > 0;
-        });
+        };
     }
 }

--- a/src/main/java/com/github/tminglei/bind/PropertyUtils.java
+++ b/src/main/java/com/github/tminglei/bind/PropertyUtils.java
@@ -13,14 +13,19 @@ import java.util.*;
  */
 public class PropertyUtils {
 
+    public static final String PROPERTY_NAME_IS_NULL = "Property name is NULL!";
+    public static final String CAN_T_FIND_PROPERTY_1$S_IN_CLASS_2$S = "Can't find property '%1$s' in class %2$s";
+    private static Map<String,Map<String,PropertyDescriptor>> pdCache =
+            Collections.synchronizedMap( new WeakHashMap<>() );
+
     public static Object readProperty( Object bean, String propName ) {
         Objects.requireNonNull(bean, "Bean object is NULL!");
-        Objects.requireNonNull(propName, "Property name is NULL!");
+        Objects.requireNonNull(propName, PROPERTY_NAME_IS_NULL);
 
         PropertyDescriptor pd = findPropertyDescriptor( bean.getClass(), propName );
 
         if( pd == null)
-            throw new IllegalArgumentException( String.format("Can't find property '%1$s' in class %2$s",
+            throw new IllegalArgumentException( String.format(CAN_T_FIND_PROPERTY_1$S_IN_CLASS_2$S,
                     propName, bean.getClass().getName()));
 
         try {
@@ -29,7 +34,7 @@ public class PropertyUtils {
             if (method == null)
                 throw new UnsupportedOperationException("Property '" + pd.getName() + "' is not readable");
 
-            return (method.invoke(bean, new Object[0]));
+            return method.invoke(bean, new Object[0]);
         }
         catch (Exception e) {
             throw new RuntimeException( String.format("Exception occurred when reading property '%1$s': %2$s",
@@ -39,12 +44,12 @@ public class PropertyUtils {
 
     public static void writeProperty( Object bean, String propName, Object propValue ) {
         Objects.requireNonNull(bean, "Bean object is NULL!");
-        Objects.requireNonNull(propName, "Property name is NULL!");
+        Objects.requireNonNull(propName, PROPERTY_NAME_IS_NULL);
 
         PropertyDescriptor pd = findPropertyDescriptor( bean.getClass(), propName );
 
         if( pd == null)
-            throw new IllegalArgumentException( String.format("Can't find property '%1$s' in class %2$s",
+            throw new IllegalArgumentException( String.format(CAN_T_FIND_PROPERTY_1$S_IN_CLASS_2$S,
                     propName, bean.getClass().getName()));
 
         try {
@@ -63,12 +68,12 @@ public class PropertyUtils {
 
     public static Class<?> getPropertyType( Class<?> beanclazz, String propName ) {
         Objects.requireNonNull(beanclazz, "Bean class is NULL!");
-        Objects.requireNonNull(propName, "Property name is NULL!");
+        Objects.requireNonNull(propName, PROPERTY_NAME_IS_NULL);
 
         PropertyDescriptor pd = findPropertyDescriptor( beanclazz, propName );
 
         if( pd == null)
-            throw new IllegalArgumentException( String.format("Can't find property '%1$s' in class %2$s",
+            throw new IllegalArgumentException( String.format(CAN_T_FIND_PROPERTY_1$S_IN_CLASS_2$S,
                     propName, beanclazz.getName()));
 
         return pd.getPropertyType();
@@ -136,8 +141,6 @@ public class PropertyUtils {
 
     //---------------------------------------------------- inner support methods ---
 
-    static Map<String,Map<String,PropertyDescriptor>> pdCache =
-            Collections.synchronizedMap( new WeakHashMap<>() );
 
     static Map<String,PropertyDescriptor> introspect( Class<?> beanclazz ) {
         Map<String,PropertyDescriptor> pdmap = pdCache.get( beanclazz.getName() );


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1192 - String literals should not be duplicated.
squid:UselessParenthesesCheck - Useless parentheses around expressions should be removed to prevent any misunderstanding.
squid:S1213 - The members of an interface declaration or class should appear in a pre-defined order.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/rules/show/squid:S1213
Please let me know if you have any questions.
George Kankava