### PR TITLE
Multiple code improvements - squid:S1596, squid:S1149, squid:S00116

### DIFF
--- a/src/main/java/com/github/tminglei/bind/BindObject.java
+++ b/src/main/java/com/github/tminglei/bind/BindObject.java
@@ -81,18 +81,18 @@ public class BindObject implements Iterable<Map.Entry<String, Object>> {
 
     @Override
     public String toString() {
-        StringBuffer buf = new StringBuffer();
+        StringBuilder builder = new StringBuilder();
         if (errors != null) {
-            buf.append("errors: ");
-            buf.append(errors);
+            builder.append("errors: ");
+            builder.append(errors);
         } else {
-            buf.append("{ ");
+            builder.append("{ ");
             data.entrySet().stream().forEach(e -> {
-                buf.append(e.getKey()).append(": ").append(e.getValue()).append(", ");
+                builder.append(e.getKey()).append(": ").append(e.getValue()).append(", ");
             });
-            buf.append(" }");
+            builder.append(" }");
         }
-        return buf.toString();
+        return builder.toString();
     }
 
 }

--- a/src/main/java/com/github/tminglei/bind/Constraints.java
+++ b/src/main/java/com/github/tminglei/bind/Constraints.java
@@ -50,7 +50,7 @@ public class Constraints {
                     }
 
                     return Arrays.asList(entry(name, errMessage));
-                } else return Collections.EMPTY_LIST;
+                } else return Collections.emptyList();
             }, mkExtensionMeta("required"));
         }
 
@@ -219,7 +219,7 @@ public class Constraints {
                         || (!withIt && value.compareTo(minVal) <= 0)) {
                     String msgTemplate = message != null ? message : messages.get("error.min");
                     return Arrays.asList(String.format(msgTemplate, value, minVal, withIt));
-                } else return Collections.EMPTY_LIST;
+                } else return Collections.emptyList();
             }, new ExtensionMeta(
                     "min",
                     "min(" + minVal + " " + (withIt ? "w/" : "w/o") + " boundary)",
@@ -248,7 +248,7 @@ public class Constraints {
                         || (!withIt && value.compareTo(maxVal) >= 0)) {
                     String msgTemplate = message != null ? message : messages.get("error.max");
                     return Arrays.asList(String.format(msgTemplate, value, maxVal, withIt));
-                } else return Collections.EMPTY_LIST;
+                } else return Collections.emptyList();
             }, new ExtensionMeta(
                 "max",
                 "max(" + maxVal + " " + (withIt ? "w/" : "w/o") + " boundary)",

--- a/src/main/java/com/github/tminglei/bind/Framework.java
+++ b/src/main/java/com/github/tminglei/bind/Framework.java
@@ -114,7 +114,7 @@ public class Framework {
         private final Logger logger = LoggerFactory.getLogger(TransformMapping.class);
 
         TransformMapping(Mapping<T> base, Function<T, R> transform) {
-            this(base, transform, Collections.EMPTY_LIST);
+            this(base, transform, Collections.emptyList());
         }
         TransformMapping(Mapping<T> base, Function<T, R> transform, List<ExtraConstraint<R>> extraConstraints) {
             this.base = base;
@@ -155,7 +155,7 @@ public class Framework {
             if (errors.isEmpty()) {
                 return Optional.ofNullable(convert(name, data))
                         .map(v -> extraValidateRec(name, v, messages, parentOptions, extraConstraints))
-                        .orElse(Collections.EMPTY_LIST);
+                        .orElse(Collections.emptyList());
             } else return errors;
         }
     }
@@ -223,14 +223,14 @@ public class Framework {
             Options theOptions = options().merge(parentOptions);
             Map<String, String> newData = processDataRec(name, data, theOptions, theOptions._processors());
 
-            if (isUntouchedEmpty(name, newData, theOptions)) return Collections.EMPTY_LIST;
+            if (isUntouchedEmpty(name, newData, theOptions)) return Collections.emptyList();
             else {
                 List<Constraint> validators = appendList(theOptions._ignoreConstraints() ? null : theOptions._constraints(), moreValidate);
                 List<Map.Entry<String, String>> errors = validateRec(name, newData, messages, theOptions, validators);
                 if (errors.isEmpty()) {
                     return Optional.ofNullable(doConvert.apply(name, newData))
                             .map(v -> extraValidateRec(name, v, messages, theOptions, theOptions._extraConstraints()))
-                            .orElse(Collections.EMPTY_LIST);
+                            .orElse(Collections.emptyList());
                 } else return errors;
             }
         }
@@ -305,11 +305,11 @@ public class Framework {
             Options theOptions = options().merge(parentOptions);
             Map<String, String> newData = processDataRec(name, data, theOptions, theOptions._processors());
 
-            if (isUntouchedEmpty(name, newData, theOptions)) return Collections.EMPTY_LIST;
+            if (isUntouchedEmpty(name, newData, theOptions)) return Collections.emptyList();
             else {
                 List<Constraint> validators = appendList(theOptions._constraints(),
                         (name1, data1, messages1, options1) -> {
-                            if (isEmptyInput(name1, data1, options1._inputMode())) return Collections.EMPTY_LIST;
+                            if (isEmptyInput(name1, data1, options1._inputMode())) return Collections.emptyList();
                             else {
                                 return fields.stream().flatMap(field -> {
                                     String fullName = isEmptyStr(name1) ? field.getKey() : name1 + "." + field.getKey();
@@ -321,7 +321,7 @@ public class Framework {
 
                 List<Map.Entry<String, String>> errors = validateRec(name, newData, messages, theOptions, validators);
                 if (errors.isEmpty()) {
-                    if (isEmptyInput(name, newData, theOptions._inputMode())) return Collections.EMPTY_LIST;
+                    if (isEmptyInput(name, newData, theOptions._inputMode())) return Collections.emptyList();
                     else {
                         BindObject vObj = doConvert(name, newData);
                         return extraValidateRec(name, vObj, messages, theOptions, theOptions._extraConstraints());

--- a/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
+++ b/src/main/java/com/github/tminglei/bind/FrameworkUtils.java
@@ -26,10 +26,10 @@ public class FrameworkUtils {
     ////////////////////////////////////////////////////////////////////////////
     public static final Function<?, ?> PASS_THROUGH = (v) -> v;
     public static final Constraint PASS_VALIDATE
-            = (name, data, messages, options) -> Collections.EMPTY_LIST;
+            = (name, data, messages, options) -> Collections.emptyList();
 
     public static <T> List<T> unmodifiableList(List<T> list) {
-        return list == null ? Collections.EMPTY_LIST : Collections.unmodifiableList(list);
+        return list == null ? Collections.emptyList() : Collections.unmodifiableList(list);
     }
 
     public static <T> List<T> appendList(List<T> list, T... others) {
@@ -135,7 +135,7 @@ public class FrameworkUtils {
                 } else {
                     String label = getLabel(name, messages, options);
                     String error = validate.apply(label, data.get(name), messages);
-                    return isEmptyStr(error) ? Collections.EMPTY_LIST
+                    return isEmptyStr(error) ? Collections.emptyList()
                             : Arrays.asList(entry(name, error));
                 }
             }, meta);
@@ -214,7 +214,7 @@ public class FrameworkUtils {
                     .flatMap(c -> c.apply(name, data, messages, options).stream())
                     .collect(Collectors.toList());
         } else {
-            if (constraints.isEmpty()) return Collections.EMPTY_LIST;
+            if (constraints.isEmpty()) return Collections.emptyList();
             else {
                 List<Map.Entry<String, String>> errors = constraints.get(0).apply(name, data, messages, options);
                 return errors.isEmpty()
@@ -292,7 +292,7 @@ public class FrameworkUtils {
             List<Map.Entry<String, String>> errErrors = new ArrayList<>();
             for(Constraint constraint : constraints) {
                 List<Map.Entry<String, String>> errors = constraint.apply(name, data, messages, options);
-                if (errors.isEmpty()) return Collections.EMPTY_LIST;
+                if (errors.isEmpty()) return Collections.emptyList();
                 else {
                     errErrors.addAll(errors);
                 }

--- a/src/main/java/com/github/tminglei/bind/Mappings.java
+++ b/src/main/java/com/github/tminglei/bind/Mappings.java
@@ -289,7 +289,7 @@ public class Mappings {
                     logger.debug("optional - validating {}", name);
 
                     if (isEmptyInput(name, data, base.options()._inputMode())) {
-                        return Collections.EMPTY_LIST;
+                        return Collections.emptyList();
                     } else { // merge the optional's constraints/label to base mapping then do validating
                         return base.options(o -> o.append_constraints(options._constraints()))
                                 .options(o -> o._label(o._label().orElse(options._label().orElse(null))))

--- a/src/main/java/com/github/tminglei/bind/Options.java
+++ b/src/main/java/com/github/tminglei/bind/Options.java
@@ -17,14 +17,14 @@ public class Options {
     private Boolean skipUntouched;
     private TouchedChecker touchedChecker;
     // internal state, only applied to current mapping
-    private InputMode _inputMode;
-    private String  _label = null;
-    private boolean _ignoreConstraints = false;
-    private List<Constraint> _constraints = Collections.EMPTY_LIST;
-    private List<ExtraConstraint<?>> _extraConstraints = Collections.EMPTY_LIST;
-    private List<PreProcessor> _processors = Collections.EMPTY_LIST;
+    private InputMode inputMode;
+    private String label = null;
+    private boolean ignoreConstraints = false;
+    private List<Constraint> constraints = Collections.emptyList();
+    private List<ExtraConstraint<?>> extraConstraints = Collections.emptyList();
+    private List<PreProcessor> processors = Collections.emptyList();
     // used to associate/hold application specific object
-    private Object _attachment;
+    private Object attachment;
 
     public Options() {}
     public Options(Boolean eagerCheck, Boolean skipUntouched, TouchedChecker touchedChecker) {
@@ -84,91 +84,91 @@ public class Options {
 
     //-- internal options
     InputMode _inputMode() {
-        return this._inputMode;
+        return this.inputMode;
     }
     Options _inputMode(InputMode inputMode) {
         Options clone = this.clone();
-        clone._inputMode = inputMode;
+        clone.inputMode = inputMode;
         return clone;
     }
 
     Optional<String> _label() {
-        return Optional.ofNullable(this._label);
+        return Optional.ofNullable(this.label);
     }
     Options _label(String label) {
         Options clone = this.clone();
-        clone._label = label;
+        clone.label = label;
         return clone;
     }
 
     boolean _ignoreConstraints() {
-        return this._ignoreConstraints;
+        return this.ignoreConstraints;
     }
     Options _ignoreConstraints(boolean ignore) {
         Options clone = this.clone();
-        clone._ignoreConstraints = ignore;
+        clone.ignoreConstraints = ignore;
         return clone;
     }
 
     List<Constraint> _constraints() {
-        return this._constraints;
+        return this.constraints;
     }
     Options _constraints(List<Constraint> constraints) {
         Options clone = this.clone();
-        clone._constraints = unmodifiableList(constraints);
+        clone.constraints = unmodifiableList(constraints);
         return clone;
     }
     Options append_constraints(List<Constraint> constraints) {
         Options clone = this.clone();
-        clone._constraints = unmodifiableList(mergeList(clone._constraints, constraints));
+        clone.constraints = unmodifiableList(mergeList(clone.constraints, constraints));
         return clone;
     }
     Options prepend_constraints(List<Constraint> constraints) {
         Options clone = this.clone();
-        clone._constraints = unmodifiableList(mergeList(constraints, clone._constraints));
+        clone.constraints = unmodifiableList(mergeList(constraints, clone.constraints));
         return clone;
     }
 
     List<PreProcessor> _processors() {
-        return this._processors;
+        return this.processors;
     }
     Options _processors(List<PreProcessor> processors) {
         Options clone = this.clone();
-        clone._processors = unmodifiableList(processors);
+        clone.processors = unmodifiableList(processors);
         return clone;
     }
     Options append_processors(List<PreProcessor> processors) {
         Options clone = this.clone();
-        clone._processors = unmodifiableList(mergeList(clone._processors, processors));
+        clone.processors = unmodifiableList(mergeList(clone.processors, processors));
         return clone;
     }
     Options prepend_processors(List<PreProcessor> processors) {
         Options clone = this.clone();
-        clone._processors = unmodifiableList(mergeList(processors, clone._processors));
+        clone.processors = unmodifiableList(mergeList(processors, clone.processors));
         return clone;
     }
 
     <T> List<ExtraConstraint<T>> _extraConstraints() {
-        return this._extraConstraints.stream().map(c -> (ExtraConstraint<T>) c).collect(Collectors.toList());
+        return this.extraConstraints.stream().map(c -> (ExtraConstraint<T>) c).collect(Collectors.toList());
     }
     Options _extraConstraints(List<ExtraConstraint<?>> extraConstraints) {
         Options clone = this.clone();
-        clone._extraConstraints = unmodifiableList(extraConstraints);
+        clone.extraConstraints = unmodifiableList(extraConstraints);
         return clone;
     }
     Options append_extraConstraints(List<ExtraConstraint<?>> extraConstraints) {
         Options clone = this.clone();
-        clone._extraConstraints = unmodifiableList(mergeList(clone._extraConstraints, extraConstraints));
+        clone.extraConstraints = unmodifiableList(mergeList(clone.extraConstraints, extraConstraints));
         return clone;
     }
 
     ///
     Object _attachment() {
-        return this._attachment;
+        return this.attachment;
     }
     Options _attachment(Object attachment) {
         Options clone = this.clone();
-        clone._attachment = attachment;
+        clone.attachment = attachment;
         return clone;
     }
 
@@ -176,13 +176,13 @@ public class Options {
 
     protected Options clone() {
         Options clone = new Options(this.eagerCheck, this.skipUntouched, this.touchedChecker);
-        clone._inputMode = this._inputMode;
-        clone._label = this._label;
-        clone._ignoreConstraints = this._ignoreConstraints;
-        clone._constraints = this._constraints;
-        clone._extraConstraints = this._extraConstraints;
-        clone._processors = this._processors;
-        clone._attachment = this._attachment;
+        clone.inputMode = this.inputMode;
+        clone.label = this.label;
+        clone.ignoreConstraints = this.ignoreConstraints;
+        clone.constraints = this.constraints;
+        clone.extraConstraints = this.extraConstraints;
+        clone.processors = this.processors;
+        clone.attachment = this.attachment;
         return clone;
     }
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rules
squid:S1596 - Collections.emptyList(), emptyMap() and emptySet() should be used instead of Collections.EMPTY_LIST, EMPTY_MAP and EMPTY_SET.
squid:S1149 - Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used.
squid:S00116 - Field names should comply with a naming convention.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1596
https://dev.eclipse.org/sonar/rules/show/squid:S1149
https://dev.eclipse.org/sonar/rules/show/squid:S00116
Please let me know if you have any questions.
George Kankava